### PR TITLE
Ignore source maps in tree generation

### DIFF
--- a/src/__snapshots__/buildTreeData.test.js.snap
+++ b/src/__snapshots__/buildTreeData.test.js.snap
@@ -92,6 +92,23 @@ Object {
 }
 `;
 
+exports[`./src/buildTreeData should ignore source maps 1`] = `
+Object {
+  "groups": Array [
+    Object {
+      "formattedGzipSize": "119 B",
+      "formattedSize": "400 B",
+      "formattedTime": "200ms",
+      "groups": Array [],
+      "isTooLarge": false,
+      "label": "mock.js",
+      "path": ".\\\\dist\\\\blah\\\\mock.js",
+      "weight": 400,
+    },
+  ],
+}
+`;
+
 exports[`./src/buildTreeData should return an empty tree for an empty bundle 1`] = `
 Object {
   "groups": Array [],

--- a/src/buildTreeData.js
+++ b/src/buildTreeData.js
@@ -20,6 +20,7 @@ function* iterateBundles(bundle) {
     yield bundle;
   }
   for (let child of bundle.childBundles) {
+    if (child.name.endsWith('.map')) continue;
     yield* iterateBundles(child);
   }
 }

--- a/src/buildTreeData.test.js
+++ b/src/buildTreeData.test.js
@@ -57,6 +57,29 @@ describe('./src/buildTreeData', () => {
     expect(tree).toMatchSnapshot();
   });
 
+  it('should ignore source maps', () => {
+    const mockParcelBundle = {
+      childBundles: new Set([
+        {
+          name: sep('dist/blah/mock.js'),
+          totalSize: 400,
+          bundleTime: 200,
+          childBundles: new Set(),
+          assets: new Set()
+        },
+        {
+          name: sep('dist/blah/mock.js.map'),
+          totalSize: 200,
+          bundleTime: 200,
+          childBundles: new Set(),
+          assets: new Set(),
+        },
+      ]),
+    };
+    const tree = buildTreeData(mockParcelBundle);
+    expect(tree).toMatchSnapshot();
+  });
+
   function sep(path) {
     const mockFolderSeperator = '\\';
     //make folder seperators consistent so we can use same test in windows and linux/mac


### PR DESCRIPTION
Fixes #15 

One liner that checks to see if a bundle name ends with map. If so, ignore the bundle and continue iterating through bundles. 

Includes a snapshot test. 

Verified by linking to my other projects. 