### PR TITLE
Allow excluding build assets by specifying globs in a config file

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -716,8 +716,7 @@
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-      "dev": true
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
     },
     "base": {
       "version": "0.11.2",
@@ -787,7 +786,6 @@
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-      "dev": true,
       "requires": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -1060,8 +1058,7 @@
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-      "dev": true
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
     },
     "convert-source-map": {
       "version": "1.6.0",
@@ -1161,6 +1158,11 @@
       "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
       "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
       "dev": true
+    },
+    "deep-extend": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA=="
     },
     "deep-is": {
       "version": "0.1.3",
@@ -2639,6 +2641,11 @@
       "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
       "dev": true
     },
+    "ini": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
+      "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw=="
+    },
     "inquirer": {
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-6.3.1.tgz",
@@ -4100,7 +4107,6 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-      "dev": true,
       "requires": {
         "brace-expansion": "^1.1.7"
       }
@@ -4693,6 +4699,24 @@
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
       "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
       "dev": true
+    },
+    "rc": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "requires": {
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+        }
+      }
     },
     "react-is": {
       "version": "16.8.6",
@@ -5499,8 +5523,7 @@
     "strip-json-comments": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-      "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
-      "dev": true
+      "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo="
     },
     "supports-color": {
       "version": "5.5.0",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,8 @@
   "dependencies": {
     "filesize": "^3.6.0",
     "gzip-size": "^4.1.0",
+    "minimatch": "^3.0.4",
+    "rc": "^1.2.8",
     "yargs": "^11.0.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
-  "name": "parcel-plugin-bundle-visualiser",
+  "name": "@studysync/parcel-plugin-bundle-visualiser",
   "version": "1.2.0",
   "description": "A plugin for the parcel bundler to visualise bundle contents",
   "author": "Greg Tillbrook",
-  "license": "MIT",
-  "repository": "gregtillbrook/parcel-plugin-bundle-visualiser",
+  "license": "UNLICENSED",
+  "repository": "https://github.com/dkadrios/parcel-plugin-bundle-visualiser.git",
   "engines": {
     "node": ">=6"
   },

--- a/src/buildTreeData.js
+++ b/src/buildTreeData.js
@@ -3,15 +3,22 @@ const path = require('path');
 const filesize = require('filesize');
 const gzipSize = require('gzip-size');
 const fs = require('fs');
+const minimatch = require('minimatch');
+
+const conf = require('rc')('bundlevisualizer', {
+  exclude: [],
+});
 
 // const WARNING = '⚠️';
 const LARGE_BUNDLE_SIZE = 1024 * 1024;
 
+const excludeBundle = ({ name }) => !conf.exclude.some(pattern => minimatch(name, pattern));
+
 module.exports = function(mainBundle) {
   return {
-    groups: Array.from(iterateBundles(mainBundle)).map(bundle =>
-      parseChildBundle(bundle)
-    ),
+    groups: Array.from(iterateBundles(mainBundle))
+      .filter(excludeBundle)
+      .map(parseChildBundle),
   };
 };
 


### PR DESCRIPTION
Background:  We have a project that imports a lot of JPGs and fonts.  These bundles were cluttering up the report and making it next to useless for analyzing our bundled JavaScript.  
By specifying which assets to exclude from the report, it makes it easier to concentrate on what's important to your team.

Example:
Contents of `.bundlevisualizer.rc`

```
{
  "exclude": [
    "**/*.gif",
    "**/*.jpg",
    "**/*.{eot,ttf,woff,woff2}"
  ]
}
```

The config file could be expanded in the future with additional switches and settings.  For instance, it might be helpful to filter child bundles too.