### PR TITLE
Fixed missed options for preview

### DIFF
--- a/preview/index.js
+++ b/preview/index.js
@@ -4,7 +4,7 @@ const parcelPluginBundleVisualiser = require('../src/index');
 
 const mockBundle = {
   childBundles: new Set([
-    {  
+    {
       name:'preview/pretend-bundles/index.js',
       totalSize:400,
       bundleTime:200,
@@ -22,7 +22,7 @@ const mockBundle = {
         }
       ])
     },
-    {  
+    {
       name:'preview/pretend-bundles/index.css',
       totalSize:300,
       bundleTime:200,
@@ -39,6 +39,11 @@ const mockBundle = {
 };
 
 const mockParcelBundler  = new EventEmitter();
+
+mockParcelBundler.options = {
+  outDir: './preview',
+};
+
 parcelPluginBundleVisualiser(mockParcelBundler);
 
 mockParcelBundler.emit('bundled', mockBundle);


### PR DESCRIPTION
Fixed error while running `preview` task

<img width="1070" alt="options outDir error" src="https://user-images.githubusercontent.com/1778432/63212356-f7573780-c10b-11e9-8e14-b19affc827b6.png">

