### PR TITLE
Only generate report if detailedReport option is set

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -6,7 +6,7 @@ const buildTreeData = require('./buildTreeData');
 const buildReportHTML = require('./buildReportHTML');
 
 module.exports = function(bundler) {
-  const isBundleReportEnabled = process.env.NODE_ENV === 'production';
+  const isBundleReportEnabled = process.env.NODE_ENV === 'production' && bundler.options.detailedReport;
 
   if (isBundleReportEnabled) {
     bundler.on('bundled', mainBundle => {


### PR DESCRIPTION
## Current behavior

Generate report if `process.env.NODE_ENV === 'production'`

## Proposed behavior

As well as checking `NODE_ENV`, we leverage Parcel's `detailedReport` option to determine whether to generate a report.

This is opposite of the plugin's existing behaviour, but affords the user control of when to generate reports, without modifying existing Parcel functionality.

Conscious this would be a breaking change, but wanted to float it, given https://github.com/gregtillbrook/parcel-plugin-bundle-visualiser/issues/14.

If the plugin's considering further development (or this is worth exploring), happy to write the tests, update docs, etc.